### PR TITLE
Fix type error in '#info-r'/-2

### DIFF
--- a/src/exprecs.erl
+++ b/src/exprecs.erl
@@ -1186,7 +1186,7 @@ f_info_1(Rname, Acc, L) ->
     Flds = get_flds(Rname, Acc),
     [funspec(L, Fname, [{[t_atom(L, fields)],
 			 t_list(L, [t_union(L, [t_atom(L,F) || F <- Flds])])},
-			{[t_atom(L, size)], t_integer(L, length(Flds))}]),
+			{[t_atom(L, size)], t_integer(L, length(Flds)+1)}]),
      {function, L, Fname, 1,
       [{clause, L, [{atom, L, fields}], [],
 	[{call, L, {atom, L, record_info},


### PR DESCRIPTION
The size of a record is the number of fields in the record plus 1.

This is the error we got when running Dialyzer

```
Invalid type specification for function XXX:'#info-YYY'/1. The success typing is ('fields' | 'size') -> [] | 1
```

and this is the function specification generated by exprecs

```
-spec '#info-YYY'(fields) -> [];
                          (size) -> 0.
```
