### PR TITLE
Fix edown dependency in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {erl_opts, [debug_info]}.
 {xref_checks, [undefined_function_calls]}.
-{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", "0.5"}}]}.
+{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", {tag, "0.5"}}}]}.
 {edoc_opts, [{doclet, edown_doclet},
 	     {top_level_readme,
               {"./README.md",


### PR DESCRIPTION
The pathspec for edown needs to be a tag (there is no `0.5` branch in edown).
