### PR TITLE
switching to Erlang/OTP 18.0 compatible version of edown

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {erl_opts, [debug_info]}.
 {xref_checks, [undefined_function_calls]}.
-{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", {tag, "0.5"}}}]}.
+{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", {branch, "master"}}}]}.
 {edoc_opts, [{doclet, edown_doclet},
 	     {top_level_readme,
               {"./README.md",

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {erl_opts, [debug_info]}.
 {xref_checks, [undefined_function_calls]}.
-{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", {branch, "master"}}}]}.
+{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", {tag, "0.7"}}}]}.
 {edoc_opts, [{doclet, edown_doclet},
 	     {top_level_readme,
               {"./README.md",


### PR DESCRIPTION
Or maybe even better: add a new tag to the updated edown repo end reference this.
Thanks!