### PR TITLE
Use only one proplist when calling ?ERROR

### DIFF
--- a/src/parse_trans.erl
+++ b/src/parse_trans.erl
@@ -879,7 +879,8 @@ apply_F(F, Type, Form, Context, Acc) ->
                     {context, Context},
                     {acc, Acc},
                     {apply_f, F},
-                    {form, Form}] ++ [{stack, ST}],
+                    {form, Form},
+                    {stack, ST}],
                    ST)
     end.
 


### PR DESCRIPTION
Just something I saw while reading through the code.