### PR TITLE
CI: Drop unused sudo: false Travis directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: erlang
-sudo: false
 otp_release:
 - 21.0
 - 20.3


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).