### PR TITLE
put all exprecs generated functions into ignore_xrefs

### DIFF
--- a/src/exprecs.erl
+++ b/src/exprecs.erl
@@ -770,6 +770,7 @@ generate_f(attribute, {attribute,L,export_records,_} = Form, _Ctxt,
           end, Es),
     {[], Form,
      [{attribute,L,export,Exports},
+      {attribute,L,ignore_xref,Exports},
       {attribute,L,export_type, TypeExports}],
      false, Acc#pass1{inserted = true}};
 generate_f(function, Form, _Context, #pass1{generated = false} = Acc) ->


### PR DESCRIPTION
rebar3 xref can automatically remove unused exports from the
xref result when they are in the ignore_xrefs module attribute.

exprecs generates a long list of exports, many of which are usually
not used. To make rebar3 xref more usable together with exprecs,
put all generated functions into ignore_xrefs to suppress them from
output.