### PR TITLE
Squash a warning on OTP 24 (master)

### DIFF
--- a/src/parse_trans.erl
+++ b/src/parse_trans.erl
@@ -30,6 +30,8 @@
 
 -module(parse_trans).
 
+-compile({no_auto_import,[error/3]}).
+
 -export([plain_transform/2]).
 
 -export([


### PR DESCRIPTION
This currently prevents bootstrapping of Rebar3 on OTP master with warnings-as-errors.