### PR TITLE
Handle annotations and locations better

### DIFF
--- a/examples/ex_gproc_send_xform.erl
+++ b/examples/ex_gproc_send_xform.erl
@@ -5,10 +5,10 @@
 parse_transform(Forms, _Options) ->
     parse_trans:light_transform(fun do_transform/1, Forms).
 
-do_transform({'op', L, '!', Lhs, Rhs}) ->
+do_transform({'op', Anno, '!', Lhs, Rhs}) ->
      [NewLhs] = parse_trans:light_transform(fun do_transform/1, [Lhs]),
      [NewRhs] = parse_trans:light_transform(fun do_transform/1, [Rhs]),
-    {call, L, {remote, L, {atom, L, gproc}, {atom, L, send}},
+    {call, Anno, {remote, Anno, {atom, Anno, gproc}, {atom, Anno, send}},
      [NewLhs, NewRhs]};
 do_transform(_) ->
     continue.

--- a/src/exprecs.erl
+++ b/src/exprecs.erl
@@ -776,7 +776,8 @@ generate_f(attribute, {attribute,L,export_records,_} = Form, _Ctxt,
      false, Acc#pass1{inserted = true}};
 generate_f(function, Form, _Context, #pass1{generated = false} = Acc) ->
     % Layout record funs before first function
-    L = erl_syntax:get_pos(Form),
+    Anno = erl_syntax:get_pos(Form),
+    L = erl_anno:location(Anno),
     Forms = generate_specs_and_accessors(L, Acc),
     {Forms, Form, [], false, Acc#pass1{generated = true}};
 generate_f(_Type, Form, _Ctxt, Acc) ->

--- a/src/exprecs.erl
+++ b/src/exprecs.erl
@@ -664,7 +664,8 @@ get_pos(I) ->
         undefined ->
             0;
         Form ->
-            erl_syntax:get_pos(Form)
+            Anno = erl_syntax:get_pos(Form),
+            erl_anno:location(Anno)
     end.
 
 -spec parse_transform(forms(), options()) ->
@@ -796,11 +797,17 @@ verify_generated(Forms, #pass1{} = Acc, _Context) ->
         false ->
             % should be re-written to use the parse_trans helper...?
             [{eof,Last}|RevForms] = lists:reverse(Forms),
+            Anno = erl_anno:new(Last),
             [{function, NewLast, _, _, _}|_] = RevAs =
-                lists:reverse(generate_specs_and_accessors(Last, Acc)),
-            lists:reverse([{eof, NewLast+1} | RevAs] ++ RevForms)
+                lists:reverse(generate_specs_and_accessors(Anno, Acc)),
+            Loc = erl_anno:location(NewLast),
+            lists:reverse([{eof, increment_line(Loc)} | RevAs] ++ RevForms)
     end.
 
+increment_line(L) when is_integer(L) ->
+    L + 1;
+increment_line({L, C}) when is_integer(L), is_integer(C) ->
+    {L + 1, C}.
 
 check_record_names(Es, L, #pass1{records = Rs}) ->
     case [E || E <- Es,
@@ -1503,7 +1510,7 @@ f_convert(_Vsns, L, Acc) ->
          [{var, L, 'Rec'}]}]],
        [{match, L, {var, L, 'Rname'},
          {call, L, {atom, L, element},
-          [{integer, L, 1}, {var, 1, 'Rec'}]}},
+          [{integer, L, 1}, {var, L, 'Rec'}]}},
         {match,L,{var,L,'Size'},
          {call, L, {atom, L, fname(info, Acc)},
           [{var,L,'Rname'}, {atom, L, size}, {var,L,'FromVsn'}]}},

--- a/src/parse_trans.erl
+++ b/src/parse_trans.erl
@@ -204,13 +204,14 @@ plain_transform1(_, F) ->
 %% @end
 %%
 -spec get_pos(list()) ->
-    integer().
+    erl_anno:location().
 get_pos(I) when is_list(I) ->
     case proplists:get_value(form, I) of
         undefined ->
             ?DUMMY_LINE;
         Form ->
-            erl_syntax:get_pos(Form)
+            Anno = erl_syntax:get_pos(Form),
+            erl_anno:location(Anno)
     end.
 
 
@@ -459,7 +460,8 @@ renumber_(T, Prev) when is_tuple(T) ->
     case is_form(T) of
         true ->
             New = Prev+1,
-            T1 = setelement(2, T, New),
+            NewE2 = update_line(element(2, T), New),
+            T1 = setelement(2, T, NewE2),
             {Res, NewAcc} = renumber_(tuple_to_list(T1), New),
             {list_to_tuple(Res), NewAcc};
         false ->
@@ -477,6 +479,16 @@ is_form(T) ->
     catch
         error:_ ->
             false
+    end.
+
+update_line(Element2, Line) ->
+    case erl_anno:is_anno(Element2) of
+        true ->
+            erl_anno:set_line(Line, Element2);
+        false -> % location
+            A = erl_anno:new(Element2),
+            NewA = erl_anno:set_line(Line, A),
+            erl_anno:location(NewA)
     end.
 
 option_value(Key, Options, Result) ->


### PR DESCRIPTION
This PR is one of several affecting repositories on Github. It
aims at fixing bad use of annotations (see erl_anno(3)). The
following remarks are common to all PR:s.

Typically the second element of abstract code tuples is assumed
to be an integer, which is no longer always true. For instance,
the parse transform implementing QLC tables (see qlc(3)) returns
code where some annotations are marked as `generated'. Such an
annotation is a list, not an integer (it used to be a negative
integer).

As of Erlang/OTP 24.0, the location can be a tuple {Line, Column},
which is another reason to handle annotations properly.