### PR TITLE
Update Travis OTP vsns (21 and later), fix try/catch and some edoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: erlang
 otp_release:
-- 23.2.3
-- 22.3.4.15
-- 21.3.8.20
+- 23.2
+- 22.3.4
+- 21.3.8
 script:
 - rebar3 eunit
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: erlang
 otp_release:
-- 23.1
+- 23.1.2
 - 22.3.4
 - 21.3.8
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: erlang
 otp_release:
-- 21.0
-- 20.3
-- 19.3
-- 18.3
+- 23.2.3
+- 22.3.4.15
+- 21.3.8.20
 script:
 - rebar3 eunit
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: erlang
 otp_release:
-- 23.2
+- 23.1
 - 22.3.4
 - 21.3.8
 script:

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Parse_trans was written in order to capture some useful patterns in parse transf
 and code generation for Erlang.
 
 Most notably, perhaps, the module [`exprecs`](http://github.com/uwiger/parse_trans/blob/master/doc/exprecs.md) generates standardized accessor
-functions for records, and `ct_expand` makes it possible to evaluate an
+functions for records, and [`ct_expand`](http://github.com/uwiger/parse_trans/blob/master/doc/ct_expand.md) makes it possible to evaluate an
 expression at compile-time and substitute the result as a compile-time constant.
 
 Less known modules, perhaps:
-* `parse_trans_pp` can be called with escript to pretty-print source from
+* [`parse_trans_pp`](http://github.com/uwiger/parse_trans/blob/master/doc/parse_trans_pp.md) can be called with escript to pretty-print source from
   debug-compiled .beam files.
-* `parse_trans_codegen` provides pseudo-functions that can be used for
+* [`parse_trans_codegen`](http://github.com/uwiger/parse_trans/blob/master/doc/parse_trans_codegen.md) provides pseudo-functions that can be used for
   simple code generation.
-* `parse_trans` provides various helper functions for traversing code and
+* [`parse_trans`](http://github.com/uwiger/parse_trans/blob/master/doc/parse_trans.md) provides various helper functions for traversing code and
   managing complex parse transforms
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 # The parse_trans application #
 
+__Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
+Parse_transform utilities
+
+[![Build Status](https://travis-ci.org/uwiger/parse_trans.svg)
+[![Hex pm](http://img.shields.io/hexpm/v/parse_trans.svg?style=flat)](https://hex.pm/packages/parse_trans)
+
+
+## Introduction ##
+
+Parse_trans was written in order to capture some useful patterns in parse transformation
+and code generation for Erlang.
+
+Most notably, perhaps, the module [`exprecs`](http://github.com/uwiger/parse_trans/blob/master/doc/exprecs.md) generates standardized accessor
+functions for records, and `ct_expand` makes it possible to evaluate an
+expression at compile-time and substitute the result as a compile-time constant.
+
+Less known modules, perhaps:
+* `parse_trans_pp` can be called with escript to pretty-print source from
+  debug-compiled .beam files.
+* `parse_trans_codegen` provides pseudo-functions that can be used for
+  simple code generation.
+* `parse_trans` provides various helper functions for traversing code and
+  managing complex parse transforms
+
 
 ## Modules ##
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -16,15 +16,15 @@ Parse_trans was written in order to capture some useful patterns in parse transf
 and code generation for Erlang.
 
 Most notably, perhaps, the module [`exprecs`](exprecs.md) generates standardized accessor
-functions for records, and `ct_expand` makes it possible to evaluate an
+functions for records, and [`ct_expand`](ct_expand.md) makes it possible to evaluate an
 expression at compile-time and substitute the result as a compile-time constant.
 
 Less known modules, perhaps:
-* `parse_trans_pp` can be called with escript to pretty-print source from
+* [`parse_trans_pp`](parse_trans_pp.md) can be called with escript to pretty-print source from
   debug-compiled .beam files.
-* `parse_trans_codegen` provides pseudo-functions that can be used for
+* [`parse_trans_codegen`](parse_trans_codegen.md) provides pseudo-functions that can be used for
   simple code generation.
-* `parse_trans` provides various helper functions for traversing code and
+* [`parse_trans`](parse_trans.md) provides various helper functions for traversing code and
   managing complex parse transforms
 
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,6 +2,31 @@
 
 # The parse_trans application #
 
+__Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
+Parse_transform utilities
+
+[![Build Status](https://travis-ci.org/uwiger/parse_trans.svg)
+[![Hex pm](http://img.shields.io/hexpm/v/parse_trans.svg?style=flat)](https://hex.pm/packages/parse_trans)
+
+
+## Introduction ##
+
+Parse_trans was written in order to capture some useful patterns in parse transformation
+and code generation for Erlang.
+
+Most notably, perhaps, the module [`exprecs`](exprecs.md) generates standardized accessor
+functions for records, and `ct_expand` makes it possible to evaluate an
+expression at compile-time and substitute the result as a compile-time constant.
+
+Less known modules, perhaps:
+* `parse_trans_pp` can be called with escript to pretty-print source from
+  debug-compiled .beam files.
+* `parse_trans_codegen` provides pseudo-functions that can be used for
+  simple code generation.
+* `parse_trans` provides various helper functions for traversing code and
+  managing complex parse transforms
+
 
 ## Modules ##
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,0 +1,25 @@
+@author Ulf Wiger <ulf@wiger.net>
+
+@doc Parse_transform utilities
+
+[![Build Status](https://travis-ci.org/uwiger/parse_trans.svg)
+[![Hex pm](http://img.shields.io/hexpm/v/parse_trans.svg?style=flat)](https://hex.pm/packages/parse_trans)
+
+<h2>Introduction</h2>
+
+Parse_trans was written in order to capture some useful patterns in parse transformation
+and code generation for Erlang.
+
+Most notably, perhaps, the module {@link exprecs} generates standardized accessor
+functions for records, and `ct_expand' makes it possible to evaluate an
+expression at compile-time and substitute the result as a compile-time constant.
+
+Less known modules, perhaps:
+* `parse_trans_pp' can be called with escript to pretty-print source from
+  debug-compiled .beam files.
+* `parse_trans_codegen' provides pseudo-functions that can be used for
+  simple code generation.
+* `parse_trans' provides various helper functions for traversing code and
+  managing complex parse transforms
+
+@end

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -11,15 +11,15 @@ Parse_trans was written in order to capture some useful patterns in parse transf
 and code generation for Erlang.
 
 Most notably, perhaps, the module {@link exprecs} generates standardized accessor
-functions for records, and `ct_expand' makes it possible to evaluate an
+functions for records, and {@link ct_expand} makes it possible to evaluate an
 expression at compile-time and substitute the result as a compile-time constant.
 
 Less known modules, perhaps:
-* `parse_trans_pp' can be called with escript to pretty-print source from
+* {@link parse_trans_pp} can be called with escript to pretty-print source from
   debug-compiled .beam files.
-* `parse_trans_codegen' provides pseudo-functions that can be used for
+* {@link parse_trans_codegen} provides pseudo-functions that can be used for
   simple code generation.
-* `parse_trans' provides various helper functions for traversing code and
+* {@link parse_trans} provides various helper functions for traversing code and
   managing complex parse transforms
 
 @end

--- a/doc/parse_trans.md
+++ b/doc/parse_trans.md
@@ -99,7 +99,7 @@ xform_f_rec() = fun((<a href="#type-type">type()</a>, <a href="#type-form">form(
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#context-2">context/2</a></td><td>
 Accessor function for the Context record.</td></tr><tr><td valign="top"><a href="#depth_first-4">depth_first/4</a></td><td></td></tr><tr><td valign="top"><a href="#do_depth_first-4">do_depth_first/4</a></td><td></td></tr><tr><td valign="top"><a href="#do_insert_forms-4">do_insert_forms/4</a></td><td></td></tr><tr><td valign="top"><a href="#do_inspect-4">do_inspect/4</a></td><td></td></tr><tr><td valign="top"><a href="#do_transform-4">do_transform/4</a></td><td></td></tr><tr><td valign="top"><a href="#error-3">error/3</a></td><td>.</td></tr><tr><td valign="top"><a href="#export_function-3">export_function/3</a></td><td></td></tr><tr><td valign="top"><a href="#format_error-1">format_error/1</a></td><td></td></tr><tr><td valign="top"><a href="#format_exception-2">format_exception/2</a></td><td>Equivalent to <a href="#format_exception-3"><tt>format_exception(Class, Reason, 4)</tt></a>.</td></tr><tr><td valign="top"><a href="#format_exception-3">format_exception/3</a></td><td>Produces a few lines of user-friendly formatting of exception info.</td></tr><tr><td valign="top"><a href="#function_exists-3">function_exists/3</a></td><td>
 Checks whether the given function is defined in Forms.</td></tr><tr><td valign="top"><a href="#get_attribute-2">get_attribute/2</a></td><td>
-Returns the value of the first occurence of attribute A.</td></tr><tr><td valign="top"><a href="#get_attribute-3">get_attribute/3</a></td><td></td></tr><tr><td valign="top"><a href="#get_file-1">get_file/1</a></td><td>
+Returns the value of the first occurrence of attribute A.</td></tr><tr><td valign="top"><a href="#get_attribute-3">get_attribute/3</a></td><td></td></tr><tr><td valign="top"><a href="#get_file-1">get_file/1</a></td><td>
 Returns the name of the file being compiled.</td></tr><tr><td valign="top"><a href="#get_module-1">get_module/1</a></td><td>
 Returns the name of the module being compiled.</td></tr><tr><td valign="top"><a href="#get_orig_syntax_tree-1">get_orig_syntax_tree/1</a></td><td>.</td></tr><tr><td valign="top"><a href="#get_pos-1">get_pos/1</a></td><td>
 Tries to retrieve the line number from an erl_syntax form.</td></tr><tr><td valign="top"><a href="#initial_context-2">initial_context/2</a></td><td>
@@ -253,7 +253,7 @@ get_attribute(A, Forms) -&gt; any()
 
 <ul class="definitions"><li><code>A = atom()</code></li></ul>
 
-Returns the value of the first occurence of attribute A.
+Returns the value of the first occurrence of attribute A.
 
 <a name="get_attribute-3"></a>
 

--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,8 @@
 %% under the License.
 %% --------------------------------------------------
 
+{minimum_otp_vsn, "21.0"}.
+
 {erl_first_files, ["src/parse_trans.erl",
                    "src/parse_trans_pp.erl",
                    "src/parse_trans_codegen.erl"]}.

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,8 @@
     {edoc_opts, [{doclet, edown_doclet},
                  {top_level_readme,
                   {"./README.md",
-                   "http://github.com/uwiger/parse_trans"}}]}
+                   "http://github.com/uwiger/parse_trans",
+                   "master"}}]}
    ]},
   {test,
    [

--- a/src/parse_trans.erl
+++ b/src/parse_trans.erl
@@ -83,6 +83,10 @@
                      type/1
                     ]).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -record(context, {module,
                   function,
                   arity,
@@ -99,12 +103,6 @@
             rpt_error(R, F, I, Trace),
             throw({error,get_pos(I),{R, Trace}})
         end).
-
--ifdef(OTP_RELEASE).
--define(WITH_STACKTRACE(T, R, S), T:R:S ->).
--else.
--define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(),).
--endif.
 
 -export_type([forms/0]).
 
@@ -328,7 +326,7 @@ do(Transform, Fun, Acc, Forms, Options) ->
             optionally_pretty_print(NewForms1, Options, Context),
             {NewForms1, Acc1}
     catch
-        ?WITH_STACKTRACE(error, Reason, ST)
+        error:Reason:ST ->
             {error,
              [{File, [{?DUMMY_LINE, ?MODULE,
                        {Reason, ST}}]}]};
@@ -348,7 +346,7 @@ top(F, Forms, Options) ->
             optionally_pretty_print(NewForms1, Options, Context),
             NewForms1
     catch
-        ?WITH_STACKTRACE(error, Reason, ST)
+        error:Reason:ST ->
             {error,
              [{File, [{?DUMMY_LINE, ?MODULE,
                        {Reason, ST}}]}]};
@@ -736,14 +734,14 @@ format_exception(Class, Reason) ->
 %%% Note that a stacktrace is generated inside this function.
 %%% @end
 format_exception(Class, Reason, Lines) ->
-    ST = erlang:process_info(self(), current_stacktrace),
+    {current_stacktrace, ST} = erlang:process_info(self(), current_stacktrace),
     PrintF = fun(Term, I) ->
                      io_lib_pretty:print(
                        Term, I, columns(), ?LINEMAX, ?CHAR_MAX,
                        record_print_fun())
              end,
     StackF = fun(_, _, _) -> false end,
-    lines(Lines, lib:format_exception(
+    lines(Lines, erl_error:format_exception(
                    1, Class, Reason, ST, StackF, PrintF)).
 
 columns() ->
@@ -874,7 +872,7 @@ this_form_df(F, Form, Context, Acc) ->
 apply_F(F, Type, Form, Context, Acc) ->
     try F(Type, Form, Context, Acc)
     catch
-        ?WITH_STACKTRACE(error, Reason, ST)
+        error:Reason:ST ->
             ?ERROR(Reason,
                    ?HERE,
                    [{type, Type},
@@ -945,3 +943,13 @@ format_error(Error) ->
 
 format_error_(Error) ->
     lists:flatten(io_lib:fwrite("~p", [Error])).
+
+
+%% EUnit
+-ifdef(TEST).
+
+format_exeption_test() ->
+    [_,_,_] = format_exception(error, {error, foo}, 3),
+    ok.
+
+-endif.


### PR DESCRIPTION
As PR #37 offered a good opportunity to hook in some eunit, this PR updates the OTP versions for Travis, and adds some status indicators in the README.md (required adding an overview.edoc, but that's a good thing too).

Since the `?WITH_STACKTRACE` macro confused edoc, and is no longer needed since OTP 21 (where also `erl_error` was introduced), this macro was removed in favor of the new try/catch syntax for stacktraces.