### PR TITLE
Keep previous behaviour

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,8 @@
                    "src/parse_trans_pp.erl",
                    "src/parse_trans_codegen.erl"]}.
 
-{erl_opts, [debug_info
+{erl_opts, [debug_info,
+            {error_location, line}
            ]}.
 {xref_checks, [undefined_function_calls]}.
 


### PR DESCRIPTION
https://github.com/uwiger/parse_trans/pull/42 introduced improvements in handling of annotations.

By default, though, in OTP 24, error locations are created as `{Line, Col}`, which breaks `parse_trans`'s assumptions of "Line as location". This pull request aims at fixing that, by making use of the recently added compiler option `error_location`.