### PR TITLE
sort ct_expand map elems + fix ct_expand trace

### DIFF
--- a/examples/ct_expand_test.erl
+++ b/examples/ct_expand_test.erl
@@ -1,8 +1,9 @@
 -module(ct_expand_test).
 
--export([f/0]).
+-export([f/0, g/0, h/0, i/0, fixture/0]).
 
 -compile({parse_transform, ct_expand}).
+-compile({ct_expand_trace, [x]}).
 -pt_pp_src(true).
 
 f() ->
@@ -29,7 +30,8 @@ fixture() ->
 jsx_consult("my_file.json", _) ->
     M0 = maps:from_list([]),
     M0#{<<"k">> => [42]
-       ,#{1=>1} => {"s", 4.2}
+       , 1 => a
+       ,#{2=>2, 1=>1} => {"s", 4.2}
        }.
 
 zip([H1|T1], [H2|T2]) ->

--- a/examples/lc.erl
+++ b/examples/lc.erl
@@ -1,7 +1,7 @@
 -module(lc).
 -export([f/1]).
 
-f(X) ->
+f(_X) ->
     [fun(_) ->
-	     erlang:now()
-     end || {Y1,Y2} <- [{1,a},{2,b}]].
+	     erlang:timestamp()
+     end || {_Y1,_Y2} <- [{1,a},{2,b}]].


### PR DESCRIPTION
Fixes #48 

As it turns out, `ct_expand_trace` was also broken, since `erl_parse:normalise/1` doesn't accept an implicit fun.