### PR TITLE
Adapt codegen:exprs substitutions to Erlang 24

### DIFF
--- a/src/parse_trans_codegen.erl
+++ b/src/parse_trans_codegen.erl
@@ -376,23 +376,32 @@ abstract(ClauseForms) ->
 
 substitute({tuple,L0,
             [{atom,_,tuple},
-             {integer,_,L},
+             Loc,
              {cons,_,
-              {tuple,_,[{atom,_,atom},{integer,_,_},{atom,_,'$var'}]},
+              {tuple,_,[{atom,_,atom},_LocA,{atom,_,'$var'}]},
               {cons,_,
-               {tuple,_,[{atom,_,var},{integer,_,_},{atom,_,V}]},
-               {nil,_}}}]}) ->
+               {tuple,_,[{atom,_,var},_LocB,{atom,_,V}]},
+               {nil,_}}}]}) when element(1, Loc) == tuple; % Erlang 24+
+                                 element(1, Loc) == integer ->
+    AbstConcreteLoc =
+        case Loc of
+            {integer, _, L} ->
+                {integer, L0, L};
+            {tuple, _, [{integer, _, L}, {integer, _, C}]} ->
+                {tuple, L0, [{integer, L0, L}, {integer, L0, C}]}
+        end,
     {call, L0, {remote,L0,{atom,L0,erl_parse},
                 {atom,L0,abstract}},
-     [{var, L0, V}, {integer, L0, L}]};
-substitute({tuple,L0,
+     [{var, L0, V}, AbstConcreteLoc]};
+substitute({tuple,L0, % Erlang 24: {Line,Col}
             [{atom,_,tuple},
-             {integer,_,_},
+             Loc,
              {cons,_,
-              {tuple,_,[{atom,_,atom},{integer,_,_},{atom,_,'$form'}]},
+              {tuple,_,[{atom,_,atom},_LocA,{atom,_,'$form'}]},
               {cons,_,
-               {tuple,_,[{atom,_,var},{integer,_,_},{atom,_,F}]},
-               {nil,_}}}]}) ->
+               {tuple,_,[{atom,_,var},_LocB,{atom,_,F}]},
+               {nil,_}}}]}) when element(1, Loc) == tuple; % Erlang 24+
+                                 element(1, Loc) == integer ->
     {var, L0, F};
 substitute([]) ->
     [];


### PR DESCRIPTION
Substitutions in codegen:exprs/1 were expecting
locations to be integers.  But with Erlang 24,
these are {Line, Column} instead. Handle both.

To illustrate the change, I'll use a function in [mockgyver_xforms](https://github.com/klajo/mockgyver/blob/f4376499/src/mockgyver_xform.erl#L87-L92):
```erlang
            [Form] = codegen:exprs(
                               fun() ->
                                       mockgyver:exec({'$var',  MockMfas},
                                                      {'$var',  TraceMfas},
                                                      {'$form', ExecFun})
                               end),
```
With Erlang 23, the parse_trans `codegen:exprs` it gets transformed to the following:
```
[{call,
  89,
  {remote, 89, {atom, 89, mockgyver}, {atom, 89, exec}},
  [erl_parse:abstract(MockMfas, 89),
   erl_parse:abstract(TraceMfas, 90),
   ExecFun]}]
```
With Erlang 24, before this PR, the expression transforms to this:
```
[{call,
  {89, 32},
  {remote,
   {89, 32},
   {atom, {89, 32}, mockgyver},
   {atom, {89, 42}, exec}},
  [{tuple,
    {89, 47},
    [{atom, {89, 48}, '$var'},
     {var, {89, 57}, 'MockMfas'}]},
   {tuple,
    {90, 47},
    [{atom, {90, 48}, '$var'},
     {var, {90, 57}, 'TraceMfas'}]},
   {tuple,
    {91, 47},
    [{atom, {91, 48}, '$form'},
     {var, {91, 57}, 'ExecFun'}]}]}]
```
With this PR, the expression now transforms to the following on Erlang 24:
```
[{call,
  {89, 32},
  {remote,
   {89, 32},
   {atom, {89, 32}, mockgyver},
   {atom, {89, 42}, exec}},
  [erl_parse:abstract(MockMfas, {89, 47}),
   erl_parse:abstract(TraceMfas, {90, 47}),
   ExecFun]}]
```
With this PR and Erlang 23, it still transforms as in the first case.